### PR TITLE
Rearrange logic so text styling works better on android

### DIFF
--- a/htmlToElement.js
+++ b/htmlToElement.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {StyleSheet, Text} from 'react-native';
+import { StyleSheet, Text } from 'react-native';
 import htmlparser from 'htmlparser2-without-node-native';
 import entities from 'entities';
 
@@ -46,7 +46,7 @@ export default function htmlToElement(rawHtml, customOpts = {}, done) {
     if (!parent) return null;
     const style = StyleSheet.flatten(opts.styles[parent.name]) || {};
     const parentStyle = inheritedStyle(parent.parent) || {};
-    return {...parentStyle, ...style};
+    return { ...parentStyle, ...style };
   }
 
   function domToElement(dom, parent) {
@@ -69,8 +69,7 @@ export default function htmlToElement(rawHtml, customOpts = {}, done) {
 
       if (!node) return null;
 
-      const {TextComponent, fontScale} = opts;
-
+      const { TextComponent, fontScale } = opts;
       if (node.type === 'text') {
         const defaultStyle = opts.textComponentProps ? opts.textComponentProps.style : null;
         const customStyle = inheritedStyle(parent);
@@ -82,7 +81,6 @@ export default function htmlToElement(rawHtml, customOpts = {}, done) {
             lineHeight: (mergedStyle.lineHeight && mergedStyle.lineHeight * fontScale) || newFontSize * 1.1
           })
         }
-
         return (
           <TextComponent
             {...opts.textComponentProps}
@@ -114,22 +112,22 @@ export default function htmlToElement(rawHtml, customOpts = {}, done) {
         let linebreakAfter = null;
         if (opts.addLineBreaks) {
           switch (node.name) {
-          case 'pre':
-            linebreakBefore = opts.lineBreak;
-            break;
-          case 'p':
-            if (index < list.length - 1) {
-              linebreakAfter = opts.paragraphBreak;
-            }
-            break;
-          case 'br':
-          case 'h1':
-          case 'h2':
-          case 'h3':
-          case 'h4':
-          case 'h5':
-            linebreakAfter = opts.lineBreak;
-            break;
+            case 'pre':
+              linebreakBefore = opts.lineBreak;
+              break;
+            case 'p':
+              if (index < list.length - 1) {
+                linebreakAfter = opts.paragraphBreak;
+              }
+              break;
+            case 'br':
+              // case 'h1':
+              // case 'h2':
+              // case 'h3':
+              // case 'h4':
+              // case 'h5':
+              linebreakAfter = opts.lineBreak;
+              break;
           }
         }
 
@@ -152,13 +150,25 @@ export default function htmlToElement(rawHtml, customOpts = {}, done) {
           }
         }
 
-        const {NodeComponent, styles} = opts;
+        const { NodeComponent, styles } = opts;
 
-        let style = node && !node.parent && node.name && styles ? styles[node.name] : null;
+        let { style } = opts.nodeComponentProps;
         if (styles && styles['paragraphDivider'] && index < dom.length - 1 && node.name && node.name === 'p') {
-           style = [styles['paragraphDivider'], style];
+          let addedStyle = styles['paragraphDivider'];
+          if (Array.isArray(style)) {
+            style = [...style, addedStyle];
+          } else {
+            style = [style, addedStyle];
+          }
         }
-
+        if (styles && node.name && styles[`${node.name}Style`]) {
+          let addedStyle = styles[`${node.name}Style`];
+          if (Array.isArray(style)) {
+            style = [...style, addedStyle];
+          } else {
+            style = [style, styles[`${node.name}Style`]];
+          }
+        }
         return (
           <NodeComponent
             {...opts.nodeComponentProps}
@@ -177,7 +187,7 @@ export default function htmlToElement(rawHtml, customOpts = {}, done) {
     });
   }
 
-  const handler = new htmlparser.DomHandler(function(err, dom) {
+  const handler = new htmlparser.DomHandler(function (err, dom) {
     if (err) done(err);
     done(null, domToElement(dom));
   });


### PR DESCRIPTION
- Remove linebreak after all headlines
- Add nodeComponentProps.style to style on NodeComponent
- Add support for `${node.name}Style` style so we can easier style text layouts on android